### PR TITLE
Patch 1

### DIFF
--- a/FixMocapSliding.py
+++ b/FixMocapSliding.py
@@ -5,21 +5,23 @@
 
 import maya.cmds
 
+#get selected sliding bone
+selectedJoint = cmds.ls(sl=True)
+cmds.select(clear=True)
+
 #create fix locator
 cmds.spaceLocator(name="fixLoc")
 cmds.scale (10,10,10, "fixLoc")
 
-#FIND AND REPLACE "Character1_Hips" with Sliding Bone Name#
-
 #parent constraint fix locator to sliding bone, unparent to get bone location before sliding
-cmds.parentConstraint ("Character1_Hips","fixLoc")
+cmds.parentConstraint (selectedJoint[0],"fixLoc")
 cmds.parent ("fixLoc_parentConstraint1", removeObject= True)
 
 #constraint sliding bone to locator to fix sliding
-cmds.parentConstraint ("fixLoc","Character1_Hips", sr=["x","y","z"])
+cmds.parentConstraint ("fixLoc",selectedJoint[0], sr=["x","y","z"])
 
 #set weight from current frame to "1", weight from previous frame to "0"
-cmds.disconnectAttr ("Character1_Hips.blendParent1","pairBlend1.weight") 
+cmds.disconnectAttr ("%s.blendParent1"%selectedJoint[0],"pairBlend1.weight") 
 cmds.select ("pairBlend1")
 cmds.setKeyframe (v=1, at="weight")
 currTime = cmds.currentTime(q=1)

--- a/FixMocapSliding.py
+++ b/FixMocapSliding.py
@@ -19,11 +19,11 @@ cmds.setAttr('%s.localScaleY'%fixLocShape[0], 10)
 cmds.setAttr('%s.localScaleZ'%fixLocShape[0], 10)
 
 #parent constraint fix locator to sliding bone, unparent to get bone location before sliding
-cmds.parentConstraint (selectedJoint[0],"fixLoc")
-cmds.parent ("fixLoc_parentConstraint1", removeObject= True)
+constraintTemp = cmds.parentConstraint(selectedJoint[0], fixLoc)
+cmds.delete(constraintTemp)
 
 #constraint sliding bone to locator to fix sliding
-cmds.parentConstraint ("fixLoc",selectedJoint[0], sr=["x","y","z"])
+cmds.parentConstraint (fixLoc, selectedJoint[0], sr=["x","y","z"])
 
 #set weight from current frame to "1", weight from previous frame to "0"
 cmds.disconnectAttr ("%s.blendParent1"%selectedJoint[0],"pairBlend1.weight") 

--- a/FixMocapSliding.py
+++ b/FixMocapSliding.py
@@ -9,9 +9,14 @@ import maya.cmds
 selectedJoint = cmds.ls(sl=True)
 cmds.select(clear=True)
 
-#create fix locator
-cmds.spaceLocator(name="fixLoc")
-cmds.scale (10,10,10, "fixLoc")
+#create fix locator and assign to variable
+fixLoc = cmds.spaceLocator(name="fixLoc")
+
+#scale locator's shape instead of transform (Safer)
+fixLocShape = cmds.listRelatives(fixLoc)
+cmds.setAttr('%s.localScaleX'%fixLocShape[0], 10)
+cmds.setAttr('%s.localScaleY'%fixLocShape[0], 10)
+cmds.setAttr('%s.localScaleZ'%fixLocShape[0], 10)
 
 #parent constraint fix locator to sliding bone, unparent to get bone location before sliding
 cmds.parentConstraint (selectedJoint[0],"fixLoc")


### PR DESCRIPTION
1) Added ability to select sliding joint in the viewport/outliner to run the script on before running the script instead of manually replacing "Character1_Hips"
2) Added a safer way to scale locators by scaling its shape instead of its transforms. Also assigned the locator to a variable instead of calling it by its name in arguments all the time.
3) Added a cleaner method of deleting temporary constraints by assigning it to a variable then using maya's default delete function to remove it instead of using the removeObject flag in the parent function.